### PR TITLE
Fixed NA-values in time

### DIFF
--- a/R/read.atekst_function.R
+++ b/R/read.atekst_function.R
@@ -45,7 +45,7 @@ read.atekst <- function(file) {
     dateRaw <- strsplit(dateRaw, " ")[[1]]
     date <- dateRaw[1]
     time <- NA
-    if (length(dateRaw) == 2) time <- dateRaw[2]
+    if (length(dateRaw) >= 2) time <- dateRaw[2]
 
     ## mode/url
     starting <- grep("Publisert p", art)[1] + 1


### PR DESCRIPTION
Some articles have been updated after publish date have more time information. This will result in more than 2 lines and the IF-statement not beeing triggered. 